### PR TITLE
More Descriptive Error Handling On Encoding Failures

### DIFF
--- a/lib/protocol_buffers/runtime/encoder.rb
+++ b/lib/protocol_buffers/runtime/encoder.rb
@@ -1,12 +1,16 @@
 module ProtocolBuffers
 
-  class EncodeError < StandardError; end
+  class EncodeError < StandardError
+    attr_reader :invalid_field
+
+    def initialize(invalid_field)
+      @invalid_field = invalid_field
+    end
+  end
 
   module Encoder # :nodoc: all
     def self.encode(io, message)
-      unless message.valid?
-        raise(EncodeError, "invalid message")
-      end
+      message.validate!
 
       message.fields.each do |tag, field|
         next unless message.value_for_tag?(tag)

--- a/lib/protocol_buffers/runtime/message.rb
+++ b/lib/protocol_buffers/runtime/message.rb
@@ -458,14 +458,25 @@ module ProtocolBuffers
       self.class.valid?(self)
     end
 
-    def self.valid?(message)
+    def self.valid?(message, raise_exception=false)
       return true unless @has_required_field
 
+      invalid_exception = nil
       fields.each do |tag, field|
-        if field.otype == :required
-          return false unless message.value_for_tag?(tag)
+        if field.otype == :required && !message.value_for_tag?(tag)
+          return false unless raise_exception
+          invalid_exception ||= ProtocolBuffers::EncodeError
+          raise(ProtocolBuffers::EncodeError.new(field), "Required field '#{field.name}' is invalid")
         end
       end
+    end
+
+    def validate!
+      self.class.validate!(self)
+    end
+
+    def self.validate!(message)
+      valid?(message, true)
     end
 
     def remember_unknown_field(tag_int, value)

--- a/lib/protocol_buffers/runtime/message.rb
+++ b/lib/protocol_buffers/runtime/message.rb
@@ -458,14 +458,23 @@ module ProtocolBuffers
       self.class.valid?(self)
     end
 
-    def self.valid?(message)
+    def self.valid?(message, raise_exception=false)
       return true unless @has_required_field
 
       fields.each do |tag, field|
-        if field.otype == :required
-          return false unless message.value_for_tag?(tag)
+        if field.otype == :required && !message.value_for_tag?(tag)
+          return false unless raise_exception
+          raise(ProtocolBuffers::EncodeError.new(field), "Required field '#{field.name}' is invalid")
         end
       end
+    end
+
+    def validate!
+      self.class.validate!(self)
+    end
+
+    def self.validate!(message)
+      valid?(message, true)
     end
 
     def remember_unknown_field(tag_int, value)

--- a/spec/runtime_spec.rb
+++ b/spec/runtime_spec.rb
@@ -333,6 +333,16 @@ describe ProtocolBuffers, "runtime" do
     res1 = TehUnknown::MyResult.new(:field_2 => 'b')
 
     proc { res1.to_s }.should raise_error(ProtocolBuffers::EncodeError)
+
+    begin
+      res1.to_s
+    rescue Exception => e
+      e.invalid_field.name.should == :field_1
+      e.invalid_field.tag.should == 1
+      e.invalid_field.otype.should == :required
+      e.invalid_field.default_value.should == ''
+    end
+
   end
 
   it "enforces required fields on deserialization" do


### PR DESCRIPTION
We needed the invalid field in the EncodeError. It makes it a lot easier to track down the encoding problem when you have deep and long models.
