### PR TITLE
add an attr_reader for proxy_class in message fields

### DIFF
--- a/lib/protocol_buffers/runtime/field.rb
+++ b/lib/protocol_buffers/runtime/field.rb
@@ -533,6 +533,8 @@ module ProtocolBuffers
 
     class MessageField < Field
       include WireFormats::LENGTH_DELIMITED
+      
+      attr_reader :proxy_class
 
       def initialize(proxy_class, otype, name, tag, opts = {})
         super(otype, name, tag, opts)

--- a/spec/fields_spec.rb
+++ b/spec/fields_spec.rb
@@ -46,4 +46,8 @@ describe ProtocolBuffers, "fields" do
     end
   end
 
+  it "provides a reader for proxy_class on message fields" do
+    ProtocolBuffers::Field::MessageField.new(nil, :optional, :fake_name, 1).should respond_to(:proxy_class)
+    ProtocolBuffers::Field::MessageField.new(Class, :optional, :fake_name, 1).proxy_class.should == Class
+  end
 end


### PR DESCRIPTION
Currently, if I want to grab the proxy class from a message field, I have to do:

`proxy_class = field.instance_variable_get('@proxy_class')`

This pull request just contains an `attr_reader` so the above code will be:

`proxy_class = field.proxy_class` or I can just avoid assigning the local variable in the first place.
