### PR TITLE
Fixes: Recursive field - Stack Level Too Deep Exception

### DIFF
--- a/lib/protocol_buffers/runtime/message.rb
+++ b/lib/protocol_buffers/runtime/message.rb
@@ -239,11 +239,14 @@ module ProtocolBuffers
           self.instance_variable_set("@#{field.name}", RepeatedField.new(field))
           @set_fields[tag] = true # repeated fields are always "set"
         else
-          value = field.default_value
-          self.__send__("#{field.name}=", value)
-          @set_fields[tag] = false
-          if field.class == Field::MessageField
-            value.notify_on_change(self, tag)
+          # If a nonrecursive MessageField, go ahead and create a default_value
+          unless field.class == Field::MessageField && self.class == field.proxy_class
+            value = field.default_value
+            self.__send__("#{field.name}=", value)
+            @set_fields[tag] = false
+            if field.class == Field::MessageField
+              value.notify_on_change(self, tag)
+            end
           end
         end
       end

--- a/spec/proto_files/featureful.proto
+++ b/spec/proto_files/featureful.proto
@@ -53,4 +53,5 @@ message ABitOfEverything {
   optional bool bool_field = 13 [default = false];
   optional string string_field = 14 [default = "zomgkittenz"];
   optional bytes bytes_field = 15;
+  optional ABitOfEverything a_bit_of_everything_field = 16;
 };

--- a/spec/runtime_spec.rb
+++ b/spec/runtime_spec.rb
@@ -265,6 +265,7 @@ describe ProtocolBuffers, "runtime" do
     bit.bool_field = true
     bit.string_field = "14"
     bit.bytes_field = "15"
+    bit.a_bit_of_everything_field = Featureful::ABitOfEverything.new
     bit
   end
 
@@ -496,13 +497,13 @@ describe ProtocolBuffers, "runtime" do
     res3 = TehUnknown3::MyResult.parse(serialized2)
     res3.field_1.should == 2
   end
-  
+
   it "can compile and instantiate a message in a package with under_scores" do
     Object.send(:remove_const, :UnderScore) if defined?(UnderScore)
-    
+
     ProtocolBuffers::Compiler.compile_and_load(
       File.join(File.dirname(__FILE__), "proto_files", "under_score_package.proto"))
-      
+
     proc do
       under_test = UnderScore::UnderTest.new
     end.should_not raise_error()


### PR DESCRIPTION
The specs all pass, but I'm not exactly sure if this fix has other implications within the codebase.

Could certainly use a few more specs for this specific case, but its a start.

Any thoughts on the current state of this?

Addresses https://github.com/mozy/ruby-protocol-buffers/issues/20
